### PR TITLE
SRRS: send commands, error handling, on-demand TRC connection

### DIFF
--- a/cmd/srrs/main_test.go
+++ b/cmd/srrs/main_test.go
@@ -76,7 +76,7 @@ func TestMain(m *testing.M) {
 func TestAll(t *testing.T) {
 	a := assert.New(t)
 
-	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost"+defaultAddr+"/state", nil)
+	conn, _, err := websocket.DefaultDialer.Dial("ws://localhost"+defaultAddr+"/"+defaultEndpoint, nil)
 	if !a.Nil(err) {
 		t.FailNow()
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,10 @@
 package api
 
-import "github.com/oklog/ulid"
+import (
+	"encoding/json"
+
+	"github.com/oklog/ulid"
+)
 
 type Command string
 
@@ -220,7 +224,7 @@ const (
 
 // Message is the structure exchanged between TRC and SRRS.
 type Message struct {
-	Type      MessageType `json:"type"`
-	MessageID ulid.ULID   `json:"message_id"`
-	Payload   []byte      `json:"payload,omitempty"`
+	Type      MessageType     `json:"type"`
+	MessageID ulid.ULID       `json:"message_id"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -87,7 +87,7 @@ func (cl *Client) do(typ MessageType, pld interface{}, v interface{}) (err error
 
 // SendCommand sends executes a global command on the TRC.
 func (cl *Client) SendCommand(c Command) error {
-	return cl.do(MessageTypeGetState, c, nil)
+	return cl.do(MessageTypeCommand, c, nil)
 }
 
 // SetState sets the state of turtles and returns the current turtle state.


### PR DESCRIPTION
- Fixed command sending in `api.Client`
- Made sure connection to the TRC socket is only opened once a websocket connection is active
- Listen for commands on the websocket, instead of the state