### PR TITLE
gitignore: Ignore IntelliJ project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ yarn-error.log
 *~
 *.swp
 *.swo
+
+# IntelliJ files
+.idea


### PR DESCRIPTION
There is a separate entry for the front end devs, as they often pick front as their root directory.