### PR TITLE
front: Setup enzyme

### DIFF
--- a/front/src/setupTests.js
+++ b/front/src/setupTests.js
@@ -1,0 +1,5 @@
+// Setup enzyme. This file will processed by create-react-app automatically.
+import Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+
+Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
I noticed that `enzyme` is not used at all. It is fine as long as our tests are simple, however, later on, we will switch completely to `enzyme`.