### PR TITLE
front: Remove title NotificationWindow

### DIFF
--- a/front/src/NotificationWindow/__snapshots__/index.test.js.snap
+++ b/front/src/NotificationWindow/__snapshots__/index.test.js.snap
@@ -13,9 +13,7 @@ exports[`NotificationWindow should display a success notification 1`] = `
   }
 >
   <styled.div>
-    <styled.h3>
-      success
-    </styled.h3>
+    <styled.p />
     <styled.button
       onClick={[Function]}
     >
@@ -51,9 +49,6 @@ exports[`NotificationWindow should display a success notification 1`] = `
       />
     </styled.button>
   </styled.div>
-  <styled.p>
-    notification message
-  </styled.p>
   <div />
 </styled.div>
 `;
@@ -71,9 +66,7 @@ exports[`NotificationWindow should display a warning notification 1`] = `
   }
 >
   <styled.div>
-    <styled.h3>
-      warning
-    </styled.h3>
+    <styled.p />
     <styled.button
       onClick={[Function]}
     >
@@ -109,9 +102,6 @@ exports[`NotificationWindow should display a warning notification 1`] = `
       />
     </styled.button>
   </styled.div>
-  <styled.p>
-    notification message
-  </styled.p>
   <div />
 </styled.div>
 `;
@@ -129,9 +119,7 @@ exports[`NotificationWindow should display an error notification 1`] = `
   }
 >
   <styled.div>
-    <styled.h3>
-      error
-    </styled.h3>
+    <styled.p />
     <styled.button
       onClick={[Function]}
     >
@@ -167,9 +155,6 @@ exports[`NotificationWindow should display an error notification 1`] = `
       />
     </styled.button>
   </styled.div>
-  <styled.p>
-    notification message
-  </styled.p>
   <div />
 </styled.div>
 `;

--- a/front/src/NotificationWindow/index.js
+++ b/front/src/NotificationWindow/index.js
@@ -20,21 +20,14 @@ const ToolBar = styled.div`
   align-items: center;
 `;
 
-const Title = styled.h3`
+const Text = styled.p`
   text-align: center;
   font-size: 4rem;
-  text-transform: uppercase;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   flex-grow: 1;
   margin: 0;
-`;
-
-const Text = styled.p`
   padding: 0 1rem;
-  text-align: center;
-  font-size: 3rem;
   overflow-wrap: break-word;
 `;
 
@@ -84,12 +77,11 @@ const NotificationWindow = props => {
     return (
       <Window background={background}>
         <ToolBar>
-          <Title>{notification.notificationType}</Title>
-          <CloseButton onClick={onDismiss}>
+          <Text>{props.message}</Text>
+          <CloseButton onClick={() => onDismiss()}>
             <FontAwesomeIcon icon={faTimes} color="black" size="4x" />
           </CloseButton>
         </ToolBar>
-        <Text>{notification.message}</Text>
         <div>{props.children}</div>
       </Window>
     );

--- a/front/src/NotificationWindow/index.test.js
+++ b/front/src/NotificationWindow/index.test.js
@@ -44,4 +44,18 @@ describe("NotificationWindow", () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
+
+  describe("gets invalid notificationType", () => {
+    it("should throw an error", () => {
+      const notification = "invalid";
+      expect(() => {
+        shallow(
+          <NotificationWindow
+            notification={notification}
+            onDismiss={() => {}}
+          />
+        );
+      }).toThrow();
+    });
+  });
 });


### PR DESCRIPTION
The title of the notification has been removed as this is implied by the color of the background. This also "fixes" that the title and the message were not directly under each other while centered.