### PR TITLE
front: Require that all javascript is formatted

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -23,7 +23,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "fmt": "eslint --fix src/**/*.js; stylelint --fix src/**/*.{css,js}"
+    "fmt": "eslint --max-warnings 0 src/{**,}/*.js && stylelint --fix src/{**,}/*.{css,js}"
   },
   "devDependencies": {
     "enzyme": "^3.3.0",


### PR DESCRIPTION
Currently, only javascript present in the build needs to be formatted. This causes issues if dead code is committed, then activated in a later commit

This commit fixes the following issues in the current linting setup:

- Eslint returns 0 if there are errors it cannot fix, so we add a flag to fix that
- Due to the nature of ; we dump eslints error code anyway, so we should use && instead
- Globstar (**) matches one or more directories, but we want to format the current directory as well, so we use an option.