### PR TITLE
front: Reduce Button Icon size.

### DIFF
--- a/front/src/BottomBar/index.js
+++ b/front/src/BottomBar/index.js
@@ -118,7 +118,7 @@ const Button = styled.button`
   background: ${props => props.theme.bottomBarButton};
   width: 100%;
   height: 50%;
-  font-size: 200%;
+  font-size: 150%;
   flex: 1;
 
   &:active {


### PR DESCRIPTION
Because it caused trouble with small mobile screens.