### PR TITLE
front: Remove redundant NotificationWindow test

### DIFF
--- a/front/src/NotificationWindow/index.test.js
+++ b/front/src/NotificationWindow/index.test.js
@@ -44,18 +44,4 @@ describe("NotificationWindow", () => {
     );
     expect(wrapper).toMatchSnapshot();
   });
-
-  describe("gets invalid notificationType", () => {
-    it("should throw an error", () => {
-      const notification = "invalid";
-      expect(() => {
-        shallow(
-          <NotificationWindow
-            notification={notification}
-            onDismiss={() => {}}
-          />
-        );
-      }).toThrow();
-    });
-  });
 });


### PR DESCRIPTION
This test case is not needed. What is more, it gives proptypes warning.