### PR TITLE
front: Change turtle storage to be an object instead of an array

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/fontawesome-free-solid": "^5.0.13",
     "@fortawesome/react-fontawesome": "^0.0.20",
     "date-fns": "^1.29.0",
+    "immutability-helper": "^2.7.0",
     "normalize.css": "^8.0.0",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -3,6 +3,7 @@ import "./App.css";
 import "normalize.css";
 import styled, { ThemeProvider } from "styled-components";
 import theme from "./theme";
+import update from "immutability-helper";
 
 import BottomBar from "./BottomBar";
 import connectionTypes from "./BottomBar/connectionTypes";
@@ -30,56 +31,50 @@ class App extends Component {
     this.state = {
       activePage: "settings",
       connectionStatus: connectionTypes.DISCONNECTED,
-      turtles: [
-        {
-          id: 1,
+      turtles: {
+        1: {
           enabled: false,
           batteryvoltage: 66,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         },
-        {
-          id: 2,
+        2: {
           enabled: false,
           batteryvoltage: 42,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         },
-        {
-          id: 3,
+        3: {
           enabled: false,
           batteryvoltage: 42,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         },
-        {
-          id: 4,
+        4: {
           enabled: false,
           batteryvoltage: 100,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         },
-        {
-          id: 5,
+        5: {
           enabled: false,
           batteryvoltage: 4,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         },
-        {
-          id: 6,
+        6: {
           enabled: false,
           batteryvoltage: 0,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         }
-      ],
+      },
       notifications: [
         { notificationType: "error", message: "Pants on fire" },
         { notificationType: "success", message: "Rendering Notifications" }
@@ -125,19 +120,9 @@ class App extends Component {
     console.log(`Sent: ${message}`);
   }
 
-  onTurtleEnableChange(position) {
+  onTurtleEnableChange(id) {
     this.setState(prev => {
-      const turtles = prev.turtles.map((turtle, index) => {
-        if (index === position) {
-          return {
-            ...turtle,
-            enabled: !turtle.enabled
-          };
-        }
-
-        return turtle;
-      });
-
+      const turtles = update(prev.turtles, { [id]: { $toggle: ["enabled"] } });
       return { turtles };
     });
   }
@@ -169,18 +154,16 @@ class App extends Component {
           {activePage === "settings" && (
             <Fragment>
               <TurtleEnableBar
-                turtles={turtles.map(turtle => {
+                turtles={Object.keys(turtles).map(id => {
                   return {
-                    id: turtle.id,
-                    enabled: turtle.enabled
+                    id: id,
+                    enabled: turtles[id].enabled
                   };
                 })}
-                onTurtleEnableChange={position =>
-                  this.onTurtleEnableChange(position)
-                }
+                onTurtleEnableChange={id => this.onTurtleEnableChange(id)}
               />
               <ScrollableContent>
-                <Settings turtles={turtles.filter(turtle => turtle.enabled)} />
+                <Settings turtles={turtles} />
               </ScrollableContent>
             </Fragment>
           )}

--- a/front/src/Settings/__snapshots__/index.test.js.snap
+++ b/front/src/Settings/__snapshots__/index.test.js.snap
@@ -59,29 +59,13 @@ exports[`renders without crashing 1`] = `
   />
   <Turtle
     editable={true}
+    id="1"
     key="1"
-    onChange={[Function]}
     turtle={
       Object {
         "batteryvoltage": 66,
         "enabled": true,
         "homegoal": "Yellow home",
-        "id": 1,
-        "role": "INACTIVE",
-        "teamcolor": "Magenta",
-      }
-    }
-  />
-  <Turtle
-    editable={true}
-    key="2"
-    onChange={[Function]}
-    turtle={
-      Object {
-        "batteryvoltage": 42,
-        "enabled": false,
-        "homegoal": "Yellow home",
-        "id": 2,
         "role": "INACTIVE",
         "teamcolor": "Magenta",
       }

--- a/front/src/Settings/index.js
+++ b/front/src/Settings/index.js
@@ -43,22 +43,16 @@ const Settings = props => {
         }}
         enabled={true}
       />
-      {turtles.map(turtle => (
-        <Turtle
-          key={turtle.id}
-          turtle={turtle}
-          editable
-          onChange={(changedProp, newValue) => {} /* TODO: turtle update */}
-        />
-      ))}
+      {Object.keys(turtles)
+        .filter(id => turtles[id].enabled)
+        .map(id => <Turtle key={id} id={id} turtle={turtles[id]} editable />)}
     </SettingsWrapper>
   );
 };
 
 Settings.propTypes = {
-  turtles: PropTypes.arrayOf(
+  turtles: PropTypes.objectOf(
     PropTypes.shape({
-      id: PropTypes.number.isRequired,
       enabled: PropTypes.bool.isRequired,
       batteryvoltage: PropTypes.number.isRequired,
       homegoal: PropTypes.string.isRequired,

--- a/front/src/Settings/index.test.js
+++ b/front/src/Settings/index.test.js
@@ -6,24 +6,22 @@ it("renders without crashing", () => {
   const wrapper = shallow(
     <Settings
       onChange={() => {}}
-      turtles={[
-        {
-          id: 1,
+      turtles={{
+        1: {
           enabled: true,
           batteryvoltage: 66,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         },
-        {
-          id: 2,
+        2: {
           enabled: false,
           batteryvoltage: 42,
           homegoal: "Yellow home",
           role: "INACTIVE",
           teamcolor: "Magenta"
         }
-      ]}
+      }}
       onTurtleEnableChange={() => {}}
     />
   );
@@ -36,24 +34,22 @@ describe("When the role assigner dropdown is changed to", () => {
   beforeEach(() => {
     wrapper = shallow(
       <Settings
-        turtles={[
-          {
-            id: 1,
+        turtles={{
+          1: {
             enabled: true,
             battery: 66,
             home: "Yellow home",
             role: "INACTIVE",
             team: "Magenta"
           },
-          {
-            id: 2,
+          2: {
             enabled: false,
             battery: 42,
             home: "Yellow home",
             role: "INACTIVE",
             team: "Magenta"
           }
-        ]}
+        }}
       />
     );
     const l = window.location;

--- a/front/src/Turtle/index.js
+++ b/front/src/Turtle/index.js
@@ -45,8 +45,8 @@ const onChange = (id, propName, propValue) => {
  * - onChange: a function with two arguments that is called when one of the dropdowns is changed. The first argument is name of the prop that is changed, the second argument is its new value.
  */
 const Turtle = props => {
-  const { batteryvoltage, homegoal, id, role, teamcolor } = props.turtle;
-  const { editable } = props;
+  const { batteryvoltage, homegoal, role, teamcolor } = props.turtle;
+  const { editable, id } = props;
   return (
     <DefaultTurtle>
       <BatterySection>
@@ -92,10 +92,10 @@ Turtle.propTypes = {
   turtle: PropTypes.shape({
     batteryvoltage: PropTypes.number,
     homegoal: PropTypes.string,
-    id: PropTypes.number,
     role: PropTypes.string,
     teamcolor: PropTypes.string
   }).isRequired,
+  id: PropTypes.string.isRequired,
   editable: PropTypes.bool,
   onChange: PropTypes.func
 };

--- a/front/src/Turtle/index.test.js
+++ b/front/src/Turtle/index.test.js
@@ -7,12 +7,11 @@ describe("Turtle", () => {
     const turtle = {
       batteryvoltage: 42,
       homegoal: "Blue home",
-      id: 2,
       role: "Goalkeeper",
       teamcolor: "Cyan"
     };
     const wrapper = shallow(
-      <Turtle turtle={turtle} editable={false} onChange={() => {}} />
+      <Turtle id="2" turtle={turtle} editable={false} onChange={() => {}} />
     );
     expect(wrapper).toMatchSnapshot();
   });
@@ -25,11 +24,10 @@ describe("Turtle", () => {
       const turtle = {
         batteryvoltage: 42,
         homegoal: "Blue home",
-        id: 2,
         role: "Goalkeeper",
         teamcolor: "Cyan"
       };
-      wrapper = shallow(<Turtle turtle={turtle} editable />);
+      wrapper = shallow(<Turtle id="2" turtle={turtle} editable />);
       global.fetch = jest.fn().mockImplementation((url, params) => {
         expect(url).toBe("/api/v1/turtles/");
         expect(params).toMatchSnapshot();

--- a/front/src/TurtleEnableBar/__snapshots__/index.test.js.snap
+++ b/front/src/TurtleEnableBar/__snapshots__/index.test.js.snap
@@ -9,15 +9,15 @@ exports[`TurtleEnableBar should render all turtles as <TurtleEnableButton /> com
     Array [
       Object {
         "enabled": false,
-        "id": 0,
+        "id": "1",
       },
       Object {
         "enabled": false,
-        "id": 1,
+        "id": "2",
       },
       Object {
         "enabled": false,
-        "id": 2,
+        "id": "3",
       },
     ]
   }
@@ -28,8 +28,8 @@ exports[`TurtleEnableBar should render all turtles as <TurtleEnableButton /> com
     >
       <TurtleEnableButton
         enabled={false}
-        id={1}
-        key="0"
+        id="1"
+        key="1"
         onTurtleEnableChange={[Function]}
       >
         <styled.button
@@ -46,8 +46,8 @@ exports[`TurtleEnableBar should render all turtles as <TurtleEnableButton /> com
       </TurtleEnableButton>
       <TurtleEnableButton
         enabled={false}
-        id={2}
-        key="1"
+        id="2"
+        key="2"
         onTurtleEnableChange={[Function]}
       >
         <styled.button
@@ -64,8 +64,8 @@ exports[`TurtleEnableBar should render all turtles as <TurtleEnableButton /> com
       </TurtleEnableButton>
       <TurtleEnableButton
         enabled={false}
-        id={3}
-        key="2"
+        id="3"
+        key="3"
         onTurtleEnableChange={[Function]}
       >
         <styled.button

--- a/front/src/TurtleEnableBar/index.js
+++ b/front/src/TurtleEnableBar/index.js
@@ -12,22 +12,22 @@ import PropTypes from "prop-types";
  *
  * Props:
  * - turtles: a list of turtles to be displayed in the bar
- *   - id: an identificator of the turtle
+ *   - id: an identificator of the turtle. Should be unique.
  *   - enabled: a boolean flag specifying whether the turtle is enabled
- * - onTurtleEnableChange: function to call when the turtle enable button is pressed
+ * - onTurtleEnableChange: function to call when the turtle enable button is pressed. The first argument is the id of the turtle that is changed.
  */
 
 const TurtleEnableBar = props => {
   const { className, onTurtleEnableChange } = props;
   return (
     <Bar className={className}>
-      {props.turtles.map((turtle, position) => {
+      {props.turtles.map(turtle => {
         return (
           <TurtleEnableButton
             key={turtle.id}
             enabled={turtle.enabled}
-            id={position + 1}
-            onTurtleEnableChange={() => onTurtleEnableChange(position)}
+            id={turtle.id}
+            onTurtleEnableChange={() => onTurtleEnableChange(turtle.id)}
           />
         );
       })}
@@ -38,7 +38,7 @@ const TurtleEnableBar = props => {
 TurtleEnableBar.propTypes = {
   turtles: PropTypes.arrayOf(
     PropTypes.shape({
-      id: PropTypes.number.isRequired,
+      id: PropTypes.string.isRequired,
       enabled: PropTypes.bool.isRequired
     })
   ).isRequired,

--- a/front/src/TurtleEnableBar/index.test.js
+++ b/front/src/TurtleEnableBar/index.test.js
@@ -15,15 +15,15 @@ describe("TurtleEnableBar", () => {
   it("should render all turtles as <TurtleEnableButton /> components", () => {
     const turtles = [
       {
-        id: 0,
+        id: "1",
         enabled: false
       },
       {
-        id: 1,
+        id: "2",
         enabled: false
       },
       {
-        id: 2,
+        id: "3",
         enabled: false
       }
     ];

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -3473,6 +3473,12 @@ ignore@^3.3.3:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
 
+immutability-helper@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.7.0.tgz#4ea9916cc8f45142ec3e3f0fce75fa5d66fa1b38"
+  dependencies:
+    invariant "^2.2.0"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -3550,7 +3556,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:


### PR DESCRIPTION
This is needed for receiving the data from the server, as that is given in a hashmap. We also make use a lot of the id for editing, so this helps here as well

Minor changes in here while I was at it: some places expected id to be a number, it is a string now, so I changed that as well. Also I removed the onChange handler from Turtle in settings, it wasn't used anymore anyway.