### PR TITLE
front: Fail tests if console.error is called

### DIFF
--- a/front/src/setupTests.js
+++ b/front/src/setupTests.js
@@ -6,3 +6,16 @@ import { WebSocket } from "mock-socket";
 Enzyme.configure({ adapter: new Adapter() });
 
 global.WebSocket = WebSocket;
+
+const realConsoleError = console.error;
+
+beforeAll(done => {
+  console.error = jest.fn().mockImplementation(msg => {
+    done.fail(
+      `You shouldn't log to console.error, caught the following message: ${msg}`
+    );
+  });
+  done();
+});
+
+afterAll(() => (console.error = realConsoleError));


### PR DESCRIPTION
This just fails the test if propTypes are violated. We can't directly test if they occur, but we can at least use them as a tripwire.