### PR TITLE
Fix refbox buttons border when in penalty mode

### DIFF
--- a/front/src/RefboxField/__snapshots__/index.test.js.snap
+++ b/front/src/RefboxField/__snapshots__/index.test.js.snap
@@ -570,12 +570,7 @@ exports[`RefboxField shows a refbox with penalty buttons 1`] = `
   flex-basis: 100%;
 }
 
-.c2:nth-child(odd) {
-  border-right: none;
-}
-
-.c2:nth-child(3),
-.c2:nth-child(4) {
+.c2:nth-child(2) {
   border-top: none;
   border-bottom: none;
 }

--- a/front/src/RefboxField/index.js
+++ b/front/src/RefboxField/index.js
@@ -108,16 +108,25 @@ const Refbox = styled.div`
 const RefboxButton = styled(Button)`
   font-size: 2.5rem;
 
-  &:nth-child(odd) {
-    border-right: none;
-  }
+  ${props =>
+    props.isPenalty
+      ? css`
+          &:nth-child(2) {
+            border-top: none;
+            border-bottom: none;
+          }
+        `
+      : css`
+          &:nth-child(odd) {
+            border-right: none;
+          }
 
-  &:nth-child(3),
-  &:nth-child(4) {
-    border-top: none;
-    border-bottom: none;
-  }
-
+          &:nth-child(3),
+          &:nth-child(4) {
+            border-top: none;
+            border-bottom: none;
+          }
+        `};
   ${media.xs`
     font-size: 4rem;
   `};


### PR DESCRIPTION
before:
<img width="385" alt="screen shot 2018-06-22 at 09 48 43" src="https://user-images.githubusercontent.com/16374166/41764545-b8efbf0e-7601-11e8-9815-db74bc80d282.png">
after:
<img width="396" alt="screen shot 2018-06-22 at 09 48 07" src="https://user-images.githubusercontent.com/16374166/41764546-b91760d6-7601-11e8-844b-caf2bddb1e2f.png">
