### PR TITLE
Disable horizontal scrolling on small devices

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -27,6 +27,7 @@ const Container = styled.div`
 const ScrollableContent = styled.div`
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 const BottomBar = styled(Bar)`

--- a/front/src/__snapshots__/App.test.js.snap
+++ b/front/src/__snapshots__/App.test.js.snap
@@ -342,6 +342,7 @@ exports[`App.js the user submits the login form the user inputs a valid token sh
   -ms-flex: 1;
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .c18 {


### PR DESCRIPTION
The `TurtleList` is still scrollable in the x direction on @No311 device.
This should fix it.